### PR TITLE
Disable chat streaming for improved security analysis

### DIFF
--- a/src/handlers/chat.rs
+++ b/src/handlers/chat.rs
@@ -15,8 +15,11 @@ impl SecurityAssessable for crate::types::ChatResponse {
 
 pub async fn handle_chat(
     State(state): State<AppState>,
-    Json(request): Json<ChatRequest>,
+    Json(mut request): Json<ChatRequest>,
 ) -> Result<Response, ApiError> {
+
+    request.stream = Some(false);
+
     debug!("Received chat request for model: {}", request.model);
 
     for message in &request.messages {

--- a/src/handlers/generate.rs
+++ b/src/handlers/generate.rs
@@ -15,8 +15,11 @@ impl SecurityAssessable for crate::types::GenerateResponse {
 
 pub async fn handle_generate(
     State(state): State<AppState>,
-    Json(request): Json<GenerateRequest>,
+    Json(mut request): Json<GenerateRequest>,
 ) -> Result<Response, ApiError> {
+
+    request.stream = Some(false);
+
     debug!("Received generate request for model: {}", request.model);
 
     let assessment = state


### PR DESCRIPTION
This PR disables chat streaming mode when using the PANW AI API proxy. Streaming responses (word-by-word delivery) prevent the security system from effectively analyzing complete content, as it can only assess fragments rather than the full context. This limitation could potentially allow security concerns to pass undetected.

The change enforces disabled streaming at the application level to ensure comprehensive security analysis of all AI-generated content.

Changes
- Modified the proxy to force stream parameter to be disabled
- Ensures security systems can analyze complete responses
- Improves detection capabilities for potential security concerns